### PR TITLE
fix(package): fix package.json trailing commas.

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,12 +70,12 @@
     "main": "dist/goldenlayout",
     "files": [
       "dist/goldenlayout.js",
-      "dist/goldenlayout.min.js",
+      "dist/goldenlayout.min.js"
     ],
     "format": "global",
     "registry": "jspm",
     "dependencies": {
-      "jquery": "*",
+      "jquery": "*"
     },
     "shim": {
       "dist/goldenlayout": ["jquery"]


### PR DESCRIPTION
npm fails to install dependencies when there are trailing commas at the last item of arrays.