### PR TITLE
fix(container): allow setSize to work with widths and heights

### DIFF
--- a/src/js/container/ItemContainer.js
+++ b/src/js/container/ItemContainer.js
@@ -72,9 +72,11 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 	setSize: function( width, height ) {
 		var rowOrColumn = this.parent,
 			rowOrColumnChild = this,
-			totalPixelHeight,
-			percentageHeight,
-			heightDelta,
+			totalPixel,
+			percentage,
+			direction,
+			newSize,
+			delta,
 			i;
 
 		while( !rowOrColumn.isColumn && !rowOrColumn.isRow ) {
@@ -90,15 +92,18 @@ lm.utils.copy( lm.container.ItemContainer.prototype, {
 			}
 		}
 
-		totalPixelHeight = this.height * ( 1 / ( rowOrColumnChild.config.height / 100 ) );
-		percentageHeight = ( height / totalPixelHeight ) * 100;
-		heightDelta = ( rowOrColumnChild.config.height - percentageHeight ) / rowOrColumn.contentItems.length;
+		direction = rowOrColumn.isColumn ? "height" : "width";
+		newSize = direction === "height" ? height : width;
+
+		totalPixel = this[direction] * ( 1 / ( rowOrColumnChild.config[direction] / 100 ) );
+		percentage = ( newSize / totalPixel ) * 100;
+		delta = ( rowOrColumnChild.config[direction] - percentage ) / rowOrColumn.contentItems.length;
 
 		for( i = 0; i < rowOrColumn.contentItems.length; i++ ) {
 			if( rowOrColumn.contentItems[ i ] === rowOrColumnChild ) {
-				rowOrColumn.contentItems[ i ].config.height = percentageHeight;
+				rowOrColumn.contentItems[ i ].config[direction] = percentage;
 			} else {
-				rowOrColumn.contentItems[ i ].config.height += heightDelta;
+				rowOrColumn.contentItems[ i ].config[direction] += delta;
 			}
 		}
 


### PR DESCRIPTION
Currently the `setSize` method on containers only works with heights but
accepts 2 parameter `width, height`. If the container is part of a row
the width is used to resize the widths of all content items. If the
container is part of a column the height is used to resize the height of
all content items.